### PR TITLE
UTF-8 fixe

### DIFF
--- a/bin/wamqg
+++ b/bin/wamqg
@@ -18,7 +18,7 @@ EM.run do
   end
 
   CHANNEL = AMQP::Channel.new(AMQP.connect(AMQP_CONFIG)) do |channel|
-    EXCHANGE = channel.topic('pub/sub', auto_delete: true) do |exchange|
+    EXCHANGE = channel.topic('pub/sub') do |exchange|
       WAMQG.start
       shutdown = false
     end

--- a/lib/wamqg.rb
+++ b/lib/wamqg.rb
@@ -25,7 +25,7 @@ class WAMQG
                 _message = {
                   routing_key: routing_key,
                   headers: headers.headers,
-                  payload: payload
+                  payload: payload.force_encoding('UTF-8')
                 }
                 ws.send _message.to_json
               end


### PR DESCRIPTION
Bytestream from AMQP was stored as ASCII-8BIT
Caused problems in .to_json function
Changed encoding to UTF-8
